### PR TITLE
Containerise

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,16 @@
+.git
+.venv
+.env
+data
+__pycache__
+*.pyc
+.pytest_cache
+.vscode
+.github
+.claude
+CLAUDE.md
+# Frontend runs outside this image (host npm, or its own service later).
+openlobbying
+ops
+Dockerfile
+docker-compose.yml

--- a/.env.example
+++ b/.env.example
@@ -1,8 +1,9 @@
-# Core application database.
-MUCKRAKE_DATABASE_URL=postgresql://myproject:secret@localhost:5432/myproject
+# Core application database (docker compose db, published on host port 5433).
+MUCKRAKE_DATABASE_URL=postgresql://muckrake:muckrake@localhost:5433/muckrake
 
 # Optional separate published database for the API. Defaults to MUCKRAKE_DATABASE_URL.
-MUCKRAKE_PUBLISHED_DATABASE_URL=postgresql://myproject:secret@localhost:5432/myproject_published
+# The compose db creates this database automatically.
+MUCKRAKE_PUBLISHED_DATABASE_URL=postgresql://muckrake:muckrake@localhost:5433/muckrake_published
 
 # Better Auth defaults.
 BETTER_AUTH_SECRET=replace-with-a-random-secret-at-least-32-characters-long

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,51 @@
+# syntax=docker/dockerfile:1
+
+# ---- Builder: resolve and install the environment with uv ----
+FROM python:3.13-slim-bookworm AS builder
+
+COPY --from=ghcr.io/astral-sh/uv:0.9 /uv /usr/local/bin/uv
+
+# plyvel (LevelDB) and pyicu (ICU) are sdist-only and compile from source.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    g++ \
+    libleveldb-dev \
+    libicu-dev \
+    pkg-config \
+    && rm -rf /var/lib/apt/lists/*
+
+# Keep the venv outside /app so a bind-mounted repo doesn't shadow it.
+ENV UV_PROJECT_ENVIRONMENT=/opt/venv \
+    UV_COMPILE_BYTECODE=1 \
+    UV_LINK_MODE=copy
+
+WORKDIR /app
+
+# Dependency layer: cached until pyproject.toml/uv.lock change.
+COPY pyproject.toml uv.lock ./
+RUN uv sync --frozen --no-install-project --no-dev
+
+# Project layer: muckrake itself (editable, pointing at /app/src).
+COPY README.md ./
+COPY src ./src
+RUN uv sync --frozen --no-dev
+
+# ---- Runtime ----
+FROM python:3.13-slim-bookworm
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libleveldb1d \
+    libicu72 \
+    && rm -rf /var/lib/apt/lists/*
+
+ENV PATH="/opt/venv/bin:$PATH" \
+    PYTHONUNBUFFERED=1
+
+COPY --from=builder /opt/venv /opt/venv
+
+WORKDIR /app
+# Full repo: the CLI reads datasets/ and writes data/ relative to the repo root.
+COPY . .
+RUN mkdir -p data
+
+EXPOSE 8000
+CMD ["muckrake", "server", "--host", "0.0.0.0"]

--- a/README.md
+++ b/README.md
@@ -86,7 +86,25 @@ cd openlobbying
 npm run dev
 ```
 
-In development, frontend requests to `/api/*` are proxied to `http://127.0.0.1:8000` via Vite.
+In development, frontend requests to `/api/*` are proxied to `http://127.0.0.1:8000` via Vite (override with `MUCKRAKE_API_URL`, e.g. `http://127.0.0.1:8001` for the containerised API).
+
+## Docker
+
+The compose stack runs Postgres 18, the API, and pipeline commands in containers. Host ports are offset (db `5433`, API `8001`) so it can run side by side with the undertheinfluence stack.
+
+```bash
+# Postgres only (creates both the app and published databases)
+docker compose up -d db
+
+# Postgres + API on http://127.0.0.1:8001
+docker compose up -d
+
+# Pipeline commands via the CLI runner
+docker compose run --rm cli list
+docker compose run --rm cli crawl gb_political_finance
+```
+
+The repo is bind-mounted into the containers, so code changes, `datasets/`, and `data/` (fetch cache + artifacts) are shared with the host. Host `uv` remains the default dev workflow; the containers are for running the full stack, e.g. alongside undertheinfluence.
 
 ## Environment setup
 

--- a/README.md
+++ b/README.md
@@ -7,9 +7,21 @@ A framework for creating and storing [FollowTheMoney](https://followthemoney.tec
 
 Muckrake is the data pipeline. It is partially inspired by [`zavod`](https://zavod.opensanctions.org/) and [other tools in the FollowTheMoney ecosystems](https://followthemoney.tech/community/stack/).
 
-Run `uv run muckrake --help` for a full list of available commands.
+### Setup
 
-Install Python dependencies with `uv sync`. This now includes the external `org-id` package used for structured organization identifiers.
+The compose stack runs Postgres 18, the API, and pipeline commands in containers. Host ports are offset (db `5433`, API `8001`) so it can run side by side with the undertheinfluence stack.
+
+```bash
+# Postgres (creates the app + published databases) and the API on http://127.0.0.1:8001
+docker compose up -d
+
+# Full list of available commands (muckrake --help)
+docker compose run --rm muckrake --help
+```
+
+The `muckrake` service's entrypoint is the muckrake CLI, so `docker compose run --rm muckrake <command>` is the container equivalent of `uv run muckrake <command>`. The repo is bind-mounted into the containers: code changes, `datasets/`, `data/` (fetch cache + artifacts) and the repo-root `.env` are shared with the host (the database URLs are overridden to point at the compose Postgres).
+
+To work on the host instead, copy `.env.example` to `.env` (see [Environment setup](#environment-setup)), install dependencies with `uv sync`, start Postgres with `docker compose up -d db`, and run commands with `uv run muckrake <command>`.
 
 Muckrake also extends the FollowTheMoney model with local `Meeting`, `Donation`, `Gift`, and `Hospitality` schemata. The package bootstrap configures `FTM_MODEL_PATH` automatically so crawls, loads, exports, releases, and the API all use the same model inside this repo.
 
@@ -17,7 +29,7 @@ Muckrake also extends the FollowTheMoney model with local `Meeting`, `Donation`,
 
 You can find crawlers for [various datasets](https://openlobbying.org/datasets) in `datasets/`. At a minimum, each dataset consists of a `config.yml` with metadata and a `crawl.py` script that outputs FollowTheMoney statements in CSV format.
 
-To crawl a dataset, run `uv run muckrake crawl {dataset_name}`. Run `uv run muckrake list` to see available datasets.
+To crawl a dataset, run `docker compose run --rm muckrake crawl {dataset_name}`. Run `docker compose run --rm muckrake list` to see available datasets.
 
 Each crawl now creates a `dataset_runs` record in Postgres and stores immutable artifacts under `MUCKRAKE_ARTIFACT_PATH` (defaults to `data/artifacts`). The latest successful run remains mirrored into `data/datasets/{name}/statements.pack.csv` for local compatibility.
 
@@ -25,12 +37,14 @@ Each crawl now creates a `dataset_runs` record in Postgres and stores immutable 
 
 Many data sources have [composite fields that contain multiple entities](https://openaccess.transparency.org.uk/?meeting=10088). We use LLMs to extract unique entities and relationships from these fields, and store them as candidates in the database for review and approval. See [NER docs](/src/muckrake/extract/ner/README.md) for details.
 
+LLM-based extraction needs `OPENROUTER_API_KEY` and `LLM_MODEL` in the repo-root `.env` — the containers pick these up through the bind mount.
+
 ```bash
 # Create extraction candidates for one dataset
-uv run muckrake ner-extract open_access --extractor llm --limit 50
+docker compose run --rm muckrake ner-extract open_access --extractor llm --limit 50
 
 # Review candidates in a terminal UI
-uv run muckrake ner-review
+docker compose run --rm muckrake ner-review
 ```
 
 ### Dedupe
@@ -39,33 +53,33 @@ Our goal is to link entities across datasets to provide a unified view of lobbyi
 
 ```bash
 # Create dedupe candidates across all datasets
-uv run muckrake xref
+docker compose run --rm muckrake xref
 
 # Review candidates in a terminal UI
-uv run muckrake dedupe
+docker compose run --rm muckrake dedupe
 ```
 
 We also want to collapse duplicate relationship edges across datasets, especially for ORCL and PRCA. This is done automatically, no review step required.
 
 ```bash
-uv run muckrake dedupe-edges
+docker compose run --rm muckrake dedupe-edges
 ```
 
 ### Loading
 
-Statements are loaded into Postgres with `uv run muckrake load`. This reads the statements CSV files and applies any approved NER candidates before materialising entities and relationships.
+Statements are loaded into Postgres with `docker compose run --rm muckrake load`. This reads the statements CSV files and applies any approved NER candidates before materialising entities and relationships.
 
 To load from a specific immutable crawl snapshot instead of the local workspace copy:
 
 ```bash
-uv run muckrake load gb_political_finance --run-id 123
+docker compose run --rm muckrake load gb_political_finance --run-id 123
 ```
 
 For the published site, prefer the release workflow instead of loading directly into the serving database:
 
 ```bash
-uv run muckrake release-build
-uv run muckrake release-publish 1
+docker compose run --rm muckrake release-build
+docker compose run --rm muckrake release-publish 1
 ```
 
 
@@ -73,11 +87,7 @@ uv run muckrake release-publish 1
 
 The primary user of Muckrake data is [OpenLobbying](https://openlobbying.org/), an open database of lobbying and political finance data.
 
-Start the API server:
-
-```bash
-uv run muckrake server
-```
+The compose stack serves the API at `http://127.0.0.1:8001` (started by `docker compose up -d`). On the host, `uv run muckrake server` serves it at `http://127.0.0.1:8000`.
 
 Start the Svelte frontend:
 
@@ -88,28 +98,10 @@ npm run dev
 
 In development, frontend requests to `/api/*` are proxied to `http://127.0.0.1:8000` via Vite (override with `MUCKRAKE_API_URL`, e.g. `http://127.0.0.1:8001` for the containerised API).
 
-## Docker
-
-The compose stack runs Postgres 18, the API, and pipeline commands in containers. Host ports are offset (db `5433`, API `8001`) so it can run side by side with the undertheinfluence stack.
-
-```bash
-# Postgres only (creates both the app and published databases)
-docker compose up -d db
-
-# Postgres + API on http://127.0.0.1:8001
-docker compose up -d
-
-# Pipeline commands via the CLI runner
-docker compose run --rm cli list
-docker compose run --rm cli crawl gb_political_finance
-```
-
-The repo is bind-mounted into the containers, so code changes, `datasets/`, and `data/` (fetch cache + artifacts) are shared with the host. Host `uv` remains the default dev workflow; the containers are for running the full stack, e.g. alongside undertheinfluence.
-
 ## Environment setup
 
 - Copy `.env.example` to `.env` in the repo root.
-- That single repo-root `.env` is used for local Python and frontend development.
+- That single repo-root `.env` is used for local Python and frontend development, and is shared with the containers via the bind mount. Docker-only use works without one (compose sets the database URLs), but LLM-based NER needs the `OPENROUTER_API_KEY`/`LLM_MODEL` values from it.
 - Required for local development:
   - `MUCKRAKE_DATABASE_URL`
 - Common local settings:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,12 +38,13 @@ services:
 
   api:
     <<: *muckrake
+    restart: unless-stopped
     command: muckrake server --host 0.0.0.0
     ports:
       - "8001:8000"
 
-  # Pipeline runner: `docker compose run --rm cli crawl <dataset>` etc.
-  cli:
+  # Pipeline runner: `docker compose run --rm muckrake crawl <dataset>` etc.
+  muckrake:
     <<: *muckrake
     entrypoint: ["muckrake"]
     profiles: ["tools"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,15 +1,52 @@
+# Standalone muckrake stack. Host ports are offset (db 5433, api 8001) so this
+# can run side by side with the undertheinfluence stack (5432/8000).
+name: muckrake
+
+x-muckrake: &muckrake
+  build: .
+  image: muckrake
+  environment:
+    MUCKRAKE_DATABASE_URL: postgresql://muckrake:muckrake@db:5432/muckrake
+    MUCKRAKE_PUBLISHED_DATABASE_URL: postgresql://muckrake:muckrake@db:5432/muckrake_published
+  volumes:
+    # Bind-mount the repo: muckrake is installed editable against /app/src, so
+    # code, datasets/ and data/ (cache + artifacts) come from the host.
+    - .:/app
+  depends_on:
+    db:
+      condition: service_healthy
+
 services:
   db:
-    image: docker.io/library/postgres:16
+    image: docker.io/library/postgres:18
     restart: unless-stopped
     environment:
-      POSTGRES_USER: myproject
-      POSTGRES_PASSWORD: secret
-      POSTGRES_DB: myproject
+      POSTGRES_USER: muckrake
+      POSTGRES_PASSWORD: muckrake
+      POSTGRES_DB: muckrake
     ports:
-      - "5432:5432"
+      - "5433:5432"
     volumes:
-      - postgres_data:/var/lib/postgresql/data
+      # postgres:18 keeps PGDATA under /var/lib/postgresql (not …/data).
+      - postgres_data:/var/lib/postgresql
+      - ./ops/docker/postgres-init:/docker-entrypoint-initdb.d:ro
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U muckrake -d muckrake"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  api:
+    <<: *muckrake
+    command: muckrake server --host 0.0.0.0
+    ports:
+      - "8001:8000"
+
+  # Pipeline runner: `docker compose run --rm cli crawl <dataset>` etc.
+  cli:
+    <<: *muckrake
+    entrypoint: ["muckrake"]
+    profiles: ["tools"]
 
 volumes:
   postgres_data:

--- a/openlobbying/vite.config.ts
+++ b/openlobbying/vite.config.ts
@@ -6,7 +6,7 @@ export default defineConfig({
 	server: {
 		proxy: {
 			'/api': {
-				target: 'http://127.0.0.1:8000',
+				target: process.env.MUCKRAKE_API_URL || 'http://127.0.0.1:8000',
 				changeOrigin: true,
 				rewrite: (path) => path.replace(/^\/api/, '')
 			}

--- a/ops/docker/postgres-init/01-create-published-db.sh
+++ b/ops/docker/postgres-init/01-create-published-db.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# Create the published (read-only API) database alongside the app database.
+set -euo pipefail
+
+psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" <<-EOSQL
+	CREATE DATABASE ${POSTGRES_DB}_published OWNER "$POSTGRES_USER";
+EOSQL


### PR DESCRIPTION
Implements the local-dev half of openlobbying/docs#9 — see openlobbying/docs#30.

### What's here

- **Multi-stage `Dockerfile`** — Python 3.13-slim + `uv` (frozen from `uv.lock`, `uv_build` backend). Builder stage compiles the sdist-only deps (`plyvel`/LevelDB, `pyicu`/ICU); the runtime stage carries only the shared libs. Venv lives at `/opt/venv` so the bind-mounted repo doesn't shadow it.
- **Standalone `docker-compose.yml`** with three services:
  - `db` — `postgres:18`, with an init script that creates the app **and** published databases
  - `api` — FastAPI server, `restart: unless-stopped`
  - `muckrake` — pipeline runner (behind the `tools` profile) whose entrypoint is the CLI, so `docker compose run --rm muckrake <command>` ≡ `uv run muckrake <command>`
- **Host ports offset** (db `5433`, API `8001`) so the stack runs side by side with the undertheinfluence stack (`5432`/`8000`). `.env.example` and the Vite proxy (`MUCKRAKE_API_URL`) updated to match.
- **Bind-mounted repo** — code, `datasets/`, `data/` (fetch cache + artifacts) and `.env` are shared with the host. Compose overrides the two database URLs to point at the in-network Postgres; everything else (e.g. `OPENROUTER_API_KEY` for NER) flows in from the repo-root `.env`.
- **`.dockerignore`** keeps `.env`, `data/`, `.git`, and the frontend out of the image.
- **README** restructured Docker-first: compose is the primary setup path, with host `uv` documented as the alternative; all pipeline examples ported to `docker compose run --rm muckrake …`.

### Constraints held

- 🔒 The compose has no knowledge of UTI — muckrake stays fully standalone. Umbrella composition is openlobbying/docs#32.
- Releases are unaffected: nothing here builds or publishes images (see discussion on openlobbying/docs#8).

### Verified

- `docker compose up -d` brings up Postgres (both DBs created) + API on `:8001`; `/datasets` and `/stats` serve from the published DB.
- Full pipeline exercised in-container: `crawl gb_committees` (~690 committees) → `load` → 6,184 statements in Postgres; `gb_members` crawl also run end to end.
- TUI commands (`ner-review`, `dedupe`) work via `docker compose run` (TTY allocated).

### Usage

    docker compose up -d                              # Postgres :5433 + API :8001
    docker compose run --rm muckrake --help           # full CLI
    docker compose run --rm muckrake crawl <dataset>