### PR TITLE
Containerise: Dockerfile + standalone compose

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,13 @@
+.git
+.venv
+.env
+data
+__pycache__
+*.pyc
+.pytest_cache
+.vscode
+.github
+.claude
+CLAUDE.md
+Dockerfile
+docker-compose.yml

--- a/.env.example
+++ b/.env.example
@@ -1,9 +1,10 @@
 # Core database. Optional.
 # By default muckrake uses SQLite files under ./data/
-# MUCKRAKE_DATABASE_URL=postgresql://myproject:secret@localhost:5432/myproject
+# The docker compose db publishes on host port 5433 and creates both databases:
+# MUCKRAKE_DATABASE_URL=postgresql://muckrake:muckrake@localhost:5433/muckrake
 
 # Optional separate published database. Defaults to MUCKRAKE_DATABASE_URL.
-# MUCKRAKE_PUBLISHED_DATABASE_URL=postgresql://myproject:secret@localhost:5432/myproject_published
+# MUCKRAKE_PUBLISHED_DATABASE_URL=postgresql://muckrake:muckrake@localhost:5433/muckrake_published
 
 # Optional local overrides.
 # MUCKRAKE_DATA_PATH=data

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,52 @@
+# syntax=docker/dockerfile:1
+
+# ---- Builder: resolve and install the environment with uv ----
+FROM python:3.13-slim-bookworm AS builder
+
+COPY --from=ghcr.io/astral-sh/uv:0.9 /uv /usr/local/bin/uv
+
+# plyvel (LevelDB) and pyicu (ICU) are sdist-only and compile from source.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    g++ \
+    libleveldb-dev \
+    libicu-dev \
+    pkg-config \
+    && rm -rf /var/lib/apt/lists/*
+
+# Keep the venv outside /app so a bind-mounted repo doesn't shadow it.
+ENV UV_PROJECT_ENVIRONMENT=/opt/venv \
+    UV_COMPILE_BYTECODE=1 \
+    UV_LINK_MODE=copy
+
+WORKDIR /app
+
+# Dependency layer: cached until pyproject.toml/uv.lock change.
+COPY pyproject.toml uv.lock ./
+RUN uv sync --frozen --no-install-project --no-dev
+
+# Project layer: muckrake itself, non-editable so the venv is self-contained
+# (the runtime stage carries no /app source; consumers run from their own
+# working directory).
+COPY README.md ./
+COPY src ./src
+RUN uv sync --frozen --no-dev --no-editable
+
+# ---- Runtime ----
+FROM python:3.13-slim-bookworm
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libleveldb1d \
+    libicu72 \
+    && rm -rf /var/lib/apt/lists/*
+
+ENV PATH="/opt/venv/bin:$PATH" \
+    PYTHONUNBUFFERED=1
+
+COPY --from=builder /opt/venv /opt/venv
+
+# Consumers run the CLI from a working directory that holds datasets/, data/
+# and .env (e.g. an application repo bind-mounted at /work).
+WORKDIR /work
+
+ENTRYPOINT ["muckrake"]
+CMD ["--help"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,15 +1,45 @@
+# Standalone muckrake stack: Postgres plus a CLI runner. Host port is offset
+# (db 5433) so this can run side by side with the undertheinfluence umbrella
+# stack (5432/8000). This compose has no knowledge of any consumer project.
+name: muckrake
+
 services:
   db:
-    image: docker.io/library/postgres:16
+    image: docker.io/library/postgres:18
     restart: unless-stopped
     environment:
-      POSTGRES_USER: myproject
-      POSTGRES_PASSWORD: secret
-      POSTGRES_DB: myproject
+      POSTGRES_USER: muckrake
+      POSTGRES_PASSWORD: muckrake
+      POSTGRES_DB: muckrake
     ports:
-      - "5432:5432"
+      - "5433:5432"
     volumes:
-      - postgres_data:/var/lib/postgresql/data
+      # postgres:18 keeps PGDATA under /var/lib/postgresql (not …/data).
+      - postgres_data:/var/lib/postgresql
+      - ./docker/postgres-init:/docker-entrypoint-initdb.d:ro
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U muckrake -d muckrake"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  # Pipeline runner: `docker compose run --rm muckrake <command>` is the
+  # container equivalent of `uv run muckrake <command>`. The repo is
+  # bind-mounted at /work, so datasets/, data/ and .env come from the host.
+  muckrake:
+    build: .
+    image: muckrake
+    entrypoint: ["muckrake"]
+    profiles: ["tools"]
+    working_dir: /work
+    environment:
+      MUCKRAKE_DATABASE_URL: postgresql://muckrake:muckrake@db:5432/muckrake
+      MUCKRAKE_PUBLISHED_DATABASE_URL: postgresql://muckrake:muckrake@db:5432/muckrake_published
+    volumes:
+      - .:/work
+    depends_on:
+      db:
+        condition: service_healthy
 
 volumes:
   postgres_data:

--- a/docker/postgres-init/01-create-published-db.sh
+++ b/docker/postgres-init/01-create-published-db.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# Create the published (read-only serving) database alongside the app database.
+set -euo pipefail
+
+psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" <<-EOSQL
+	CREATE DATABASE ${POSTGRES_DB}_published OWNER "$POSTGRES_USER";
+EOSQL


### PR DESCRIPTION
Redo of #19 for the post-split repo. Implements the muckrake half of the local-dev containerisation (openlobbying/docs#9); closes openlobbying/docs#30.

### What's here

- **Multi-stage `Dockerfile`** (carried over from #19): Python 3.13-slim + `uv` frozen from `uv.lock`; builder stage compiles the sdist-only deps (`plyvel`/LevelDB, `pyicu`/ICU), runtime carries only the shared libs; venv at `/opt/venv`.
- **Changed from #19: non-editable install** (`uv sync --no-editable`). The editable install pointed at `/app/src`, which broke when the CLI ran from a different working directory. The venv is now self-contained, so consumers mount any working directory (this repo at `/work` in the standalone compose; the openlobbying checkout in the undertheinfluence umbrella compose).
- **Changed from #19: no `api` service** — `muckrake server` moved to the openlobbying repo with the API in the repo split. The standalone stack is now `postgres:18` (host **5433**, init script creates the `muckrake` + `muckrake_published` databases) plus the CLI runner behind the `tools` profile: `docker compose run --rm muckrake <command>`.
- Init script lives at `docker/postgres-init/` (`ops/` also moved out in the split). `.env.example` commented URLs updated to the 5433 compose ports.
- 🔒 held: the compose has no knowledge of any consumer project.

### Verified

- Image builds clean; `docker compose config` passes.
- End to end via the undertheinfluence umbrella compose (which builds this image): `list` discovers all 12 datasets through the workdir mount; `crawl gb_committees` → `load` → **6,184 statements / 687 entities** in Postgres — matching the figure verified on #19.

The old `containerise` branch from #19 is superseded by this one and can be deleted.