### PR TITLE
Resilient fetch layer: shared polite session with retry, backoff and rate limiting

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,3 +19,7 @@
 # LLM_MODEL=
 # NER_LLM_PROMPT_FILE=
 # LOGFIRE_TOKEN=
+
+# Minimum interval in seconds between HTTP requests to the same host
+# (politeness rate limit; off by default).
+# MUCKRAKE_HTTP_MIN_INTERVAL=0.5

--- a/src/muckrake/extract/fetch.py
+++ b/src/muckrake/extract/fetch.py
@@ -1,18 +1,81 @@
 import json
+import os
+import threading
 import time
 import requests
+from functools import cache
+from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path
 from typing import Optional, Any, TYPE_CHECKING
+from urllib.parse import urlparse
 from lxml import html
 from lxml.html import HtmlElement
 from banal import hash_data
+from requests.adapters import HTTPAdapter
 from rigour.urls import build_url
+from urllib3.util.retry import Retry
 import logging
 
 if TYPE_CHECKING:
     from nomenklatura.cache import Cache
 
 log = logging.getLogger(__name__)
+
+RETRY_STATUSES = (429, 500, 502, 503, 504)
+
+
+def _user_agent() -> str:
+    try:
+        pkg_version = version("muckrake")
+    except PackageNotFoundError:
+        pkg_version = "dev"
+    return f"muckrake/{pkg_version} (+https://github.com/openlobbying/muckrake)"
+
+
+def make_session(retries: int = 5, backoff_factor: float = 1.0) -> requests.Session:
+    """A polite HTTP session: connection pooling, a muckrake User-Agent, and
+    retry with exponential backoff on transient failures (connection errors
+    and 429/5xx statuses, honouring Retry-After). Only idempotent methods
+    (GET/HEAD) are retried — a failed POST is raised immediately."""
+    session = requests.Session()
+    retry = Retry(
+        total=retries,
+        backoff_factor=backoff_factor,
+        status_forcelist=RETRY_STATUSES,
+        allowed_methods=("GET", "HEAD"),
+        respect_retry_after_header=True,
+        raise_on_status=False,
+    )
+    adapter = HTTPAdapter(max_retries=retry)
+    session.mount("http://", adapter)
+    session.mount("https://", adapter)
+    session.headers["User-Agent"] = _user_agent()
+    return session
+
+
+@cache
+def get_session() -> requests.Session:
+    """The shared session used whenever a caller does not supply one."""
+    return make_session()
+
+
+_throttle_lock = threading.Lock()
+_next_request_at: dict[str, float] = {}
+
+
+def _throttle(url: str) -> None:
+    """Enforce a minimum interval between requests to the same host
+    (MUCKRAKE_HTTP_MIN_INTERVAL, seconds; off by default)."""
+    interval = float(os.getenv("MUCKRAKE_HTTP_MIN_INTERVAL") or 0)
+    if interval <= 0:
+        return
+    host = urlparse(url).netloc
+    with _throttle_lock:
+        now = time.monotonic()
+        wait = _next_request_at.get(host, now) - now
+        _next_request_at[host] = max(now, _next_request_at.get(host, now)) + interval
+    if wait > 0:
+        time.sleep(wait)
 
 
 def request_hash(
@@ -46,7 +109,8 @@ def fetch_file(
 
     log.info("Fetching file from %s", url)
     out_path.parent.mkdir(parents=True, exist_ok=True)
-    requester = session.request if session is not None else requests.request
+    requester = (session or get_session()).request
+    _throttle(url)
 
     with requester(
         method=method,
@@ -93,7 +157,8 @@ def fetch_text(
             time.sleep(sleep)
 
     log.debug("HTTP %s: %s", method, url)
-    requester = session.request if session is not None else requests.request
+    requester = (session or get_session()).request
+    _throttle(url)
     response = requester(
         method=method,
         url=url,

--- a/tests/test_fetch.py
+++ b/tests/test_fetch.py
@@ -1,0 +1,72 @@
+import threading
+import time
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+import pytest
+
+from muckrake.extract.fetch import fetch_text, get_session, make_session
+
+
+class Handler(BaseHTTPRequestHandler):
+    failures_remaining = 0
+    seen_user_agents: list[str] = []
+    request_times: list[float] = []
+
+    def do_GET(self):
+        Handler.seen_user_agents.append(self.headers.get("User-Agent", ""))
+        Handler.request_times.append(time.monotonic())
+        if Handler.failures_remaining > 0:
+            Handler.failures_remaining -= 1
+            self.send_response(503)
+            self.end_headers()
+            return
+        body = b"ok"
+        self.send_response(200)
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, *args):
+        pass
+
+
+@pytest.fixture
+def server_url():
+    server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    Handler.failures_remaining = 0
+    Handler.seen_user_agents = []
+    Handler.request_times = []
+    yield f"http://127.0.0.1:{server.server_address[1]}/"
+    server.shutdown()
+
+
+def test_retries_transient_statuses(server_url):
+    Handler.failures_remaining = 2
+    session = make_session(retries=3, backoff_factor=0.01)
+    assert fetch_text(server_url, session=session) == "ok"
+    assert len(Handler.request_times) == 3
+
+
+def test_exhausted_retries_raise(server_url):
+    Handler.failures_remaining = 10
+    session = make_session(retries=2, backoff_factor=0.01)
+    with pytest.raises(Exception):
+        fetch_text(server_url, session=session)
+
+
+def test_default_session_sets_user_agent(server_url):
+    assert fetch_text(server_url) == "ok"
+    assert Handler.seen_user_agents[-1].startswith("muckrake/")
+
+
+def test_per_host_min_interval(server_url, monkeypatch):
+    monkeypatch.setenv("MUCKRAKE_HTTP_MIN_INTERVAL", "0.3")
+    fetch_text(server_url, params={"q": "1"})
+    fetch_text(server_url, params={"q": "2"})
+    assert Handler.request_times[1] - Handler.request_times[0] >= 0.25
+
+
+def test_shared_session_is_reused():
+    assert get_session() is get_session()


### PR DESCRIPTION
Implements the resilient-fetch half of the Data-plane hardening workstream (openlobbying/docs#23):

- **Unified client**: `make_session()` builds a polite `requests.Session` — connection pooling, `muckrake/<version>` User-Agent — and a `functools.cache`d `get_session()` is now the default whenever a caller doesn't pass `session=` to `fetch_text/json/html/file` (previously each call was a bare one-shot `requests.request`).
- **Retry + backoff**: urllib3 `Retry` on the adapter — connection errors and 429/500/502/503/504, exponential backoff, `Retry-After` honoured. Idempotent methods (GET/HEAD) only; a failed POST still raises immediately.
- **Rate limit**: opt-in per-host minimum interval between requests via `MUCKRAKE_HTTP_MIN_INTERVAL` (seconds; off by default so existing crawl behaviour is unchanged). Documented in `.env.example`.
- Behaviour otherwise unchanged: same timeouts (120s default), same DB-backed response cache, `raise_for_status()` still crashes loudly after retries are exhausted.

Tests (`tests/test_fetch.py`, against a live in-process HTTP server): retry-to-success on transient 503s, exhausted retries raise, default session sets the User-Agent, per-host interval enforced, shared session reused. Full suite: 17 passed.

No new dependencies — urllib3 `Retry` ships with requests.

https://claude.ai/code/session_01DRkQXYMJL6gBjz9nMLvFro