### PR TITLE
parse_day_range: cross-month ranges with omitted start year and underscore separator

### DIFF
--- a/src/muckrake/utils/dates.py
+++ b/src/muckrake/utils/dates.py
@@ -224,7 +224,7 @@ def parse_day_range(value: Any, start: Optional[date] = None, end: Optional[date
         if start_date is None or end_date is None:
             return None
         return start_date, end_date
-    match = re.fullmatch(r"(\d{1,2})(?:-|\s+to\s+)(\d{1,2})\s+([A-Za-z]+)(?:\s+(\d{2,4}))?", text)
+    match = re.fullmatch(r"(\d{1,2})(?:\s*[-_]\s*|\s+to\s+)(\d{1,2})\s+([A-Za-z]+)(?:\s+(\d{2,4}))?", text)
     if match is not None:
         month = month_number(match.group(3))
         if month is None:
@@ -258,25 +258,35 @@ def parse_day_range(value: Any, start: Optional[date] = None, end: Optional[date
             return None
         return start_date, end_date
 
-    match = re.fullmatch(r"(\d{1,2})\s+([A-Za-z]+)\s+(\d{2,4})-(\d{1,2})\s+([A-Za-z]+)\s+(\d{2,4})", text)
+    # Cross-month ranges: "27 Sep 15-01 Oct 15", "27 Sep _ 01 Oct 15" (the
+    # start year may be omitted; historical files use "_" as the separator).
+    match = re.fullmatch(
+        r"(\d{1,2})\s+([A-Za-z]+)(?:\s+(\d{2,4}))?\s*[-_]\s*(\d{1,2})\s+([A-Za-z]+)\s+(\d{2,4})",
+        text,
+    )
     if match is not None:
         start_month = month_number(match.group(2))
         end_month = month_number(match.group(5))
         if start_month is None or end_month is None:
             return None
-        start_year = int(match.group(3))
         end_year = int(match.group(6))
-        if start_year < 100:
-            start_year += 2000
         if end_year < 100:
             end_year += 2000
+        if match.group(3) is not None:
+            start_year = int(match.group(3))
+            if start_year < 100:
+                start_year += 2000
+        elif start_month > end_month:
+            start_year = end_year - 1
+        else:
+            start_year = end_year
         start_date = safe_iso_date(start_year, start_month, int(match.group(1)))
         end_date = safe_iso_date(end_year, end_month, int(match.group(4)))
         if start_date is None or end_date is None:
             return None
         return start_date, end_date
 
-    match = re.fullmatch(r"(\d{1,2})\s+([A-Za-z]+)(?:-|\s+to\s+)(\d{1,2})\s+([A-Za-z]+)(?:\s+(\d{2,4}))?", text)
+    match = re.fullmatch(r"(\d{1,2})\s+([A-Za-z]+)(?:\s*[-_]\s*|\s+to\s+)(\d{1,2})\s+([A-Za-z]+)(?:\s+(\d{2,4}))?", text)
     if match is None:
         return None
     start_month = month_number(match.group(2))

--- a/tests/test_dates.py
+++ b/tests/test_dates.py
@@ -1,0 +1,43 @@
+from datetime import date
+
+from muckrake.utils.dates import parse_day_range
+
+
+def test_cross_month_range_with_underscore_and_omitted_start_year():
+    # The exact cell that killed a 14.6h gov_transparency crawl
+    # (openlobbying/openlobbying#29).
+    assert parse_day_range("27 Sep _ 01 Oct 15") == ("2015-09-27", "2015-10-01")
+
+
+def test_cross_month_range_with_both_years():
+    assert parse_day_range("27 Sep 15-01 Oct 15") == ("2015-09-27", "2015-10-01")
+    assert parse_day_range("27 Sep 2015 - 1 Oct 2015") == ("2015-09-27", "2015-10-01")
+
+
+def test_cross_month_range_omitted_start_year_infers_from_end():
+    assert parse_day_range("30 Dec _ 02 Jan 16") == ("2015-12-30", "2016-01-02")
+
+
+def test_same_month_range_with_underscore_separator():
+    assert parse_day_range("8_12 July 2015") == ("2015-07-08", "2015-07-12")
+
+
+def test_same_month_range_still_parses():
+    assert parse_day_range("8-12 July 2015") == ("2015-07-08", "2015-07-12")
+    assert parse_day_range("8 to 12 July 2015") == ("2015-07-08", "2015-07-12")
+    assert parse_day_range(
+        "8-12 July", start=date(2015, 4, 1), end=date(2015, 9, 30)
+    ) == ("2015-07-08", "2015-07-12")
+
+
+def test_slash_day_pair_range_still_parses():
+    assert parse_day_range("8/9 July 2015") == ("2015-07-08", "2015-07-09")
+
+
+def test_numeric_range_still_parses():
+    assert parse_day_range("08/07/2015-09/07/2015") == ("2015-07-08", "2015-07-09")
+
+
+def test_garbage_returns_none():
+    assert parse_day_range("not a date") is None
+    assert parse_day_range("27 Sep _ 01 Vember 15") is None


### PR DESCRIPTION
Fixes the parser gap behind openlobbying/openlobbying#29 (a single 2015 cell — `27 Sep _ 01 Oct 15` — killed a 14.6h `gov_transparency` crawl).

- The cross-month pattern now allows the **start year to be omitted** (inferred from the end year, with Dec→Jan year-boundary handling) and accepts `_` as a separator alongside `-`/`to` — both forms appear in historical gov.uk CSVs.
- Same-month patterns also accept `_`.
- Unparseable values still return None → the caller still crashes loudly; this only widens what counts as a well-formed range.

Tests: `tests/test_dates.py` — regression case is the exact failing cell, plus year-inference across Dec–Jan, all pre-existing forms, and garbage rejection. Full suite 25 passed.

https://claude.ai/code/session_01DRkQXYMJL6gBjz9nMLvFro