### PR TITLE
Introduce test coverage across muckrake core

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,91 @@
-import muckrake
+from __future__ import annotations
+
+# muckrake.settings reads the DB URIs and data/artifact paths from the
+# environment *at import time* (they become module-level constants that many
+# core write paths — load, release, runs — capture as default arguments). So the
+# environment has to be pointed at throwaway locations before muckrake is
+# imported. conftest is the earliest module pytest loads, and a plain
+# ``import muckrake`` does not pull in settings, so setting the vars here — ahead
+# of the import below — gives the whole suite an isolated SQLite working DB and a
+# separate published DB, with no network access or repo-data side effects.
+import os
+import tempfile
+import uuid
+from pathlib import Path
+from typing import Any, Callable
+
+_TEST_ROOT = Path(tempfile.mkdtemp(prefix="muckrake-tests-"))
+os.environ.pop("MUCKRAKE_DATABASE_URL", None)  # working DB falls back to the SQLite default
+os.environ["MUCKRAKE_ENV_FILE"] = str(_TEST_ROOT / "missing.env")
+os.environ["MUCKRAKE_DATA_PATH"] = str(_TEST_ROOT / "data")
+os.environ["MUCKRAKE_ARTIFACT_PATH"] = str(_TEST_ROOT / "data" / "artifacts")
+os.environ["MUCKRAKE_PUBLISHED_DATABASE_URL"] = (
+    f"sqlite:///{(_TEST_ROOT / 'published.db').as_posix()}"
+)
+# The default SQLite working DB lives under MUCKRAKE_DATA_PATH; create it so the
+# engine can open the file even in tests that touch the DB without first writing
+# a dataset pack.
+(_TEST_ROOT / "data").mkdir(parents=True, exist_ok=True)
+
+import muckrake  # noqa: E402  (must follow the env setup above)
+
+import pytest  # noqa: E402
+import yaml  # noqa: E402
+from followthemoney.statement.serialize import PackStatementWriter  # noqa: E402
+
+from muckrake.dataset import Dataset, get_dataset_path  # noqa: E402
 
 __all__ = ["muckrake"]
+
+
+# A dataset spec: a schema name plus the properties to set. An explicit ``id`` may
+# be supplied, otherwise a stable hashed id is derived from the schema name.
+DatasetSpec = dict[str, Any]
+
+
+@pytest.fixture
+def make_dataset(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> Callable[..., tuple[str, Path]]:
+    """Write a throwaway dataset and return ``(name, pack_path)``.
+
+    Creates a ``config.yml`` discoverable via ``MUCKRAKE_DATASET_PATHS`` and, when
+    ``write_pack`` is true, a ``statements.pack.csv`` at the dataset's default
+    location built from ``entities``. Pass ``write_pack=False`` to leave the pack
+    absent (to exercise the missing-pack path).
+    """
+    roots = tmp_path / "datasets"
+    roots.mkdir()
+    monkeypatch.setenv("MUCKRAKE_DATASET_PATHS", str(roots))
+
+    def _make(
+        entities: list[DatasetSpec] | None = None,
+        *,
+        name: str | None = None,
+        write_pack: bool = True,
+    ) -> tuple[str, Path]:
+        name = name or f"ds_{uuid.uuid4().hex[:8]}"
+        config_dir = roots / name
+        config_dir.mkdir(parents=True)
+        config_path = config_dir / "config.yml"
+        config_path.write_text(
+            yaml.safe_dump({"name": name, "title": name, "prefix": name})
+        )
+
+        pack_path = get_dataset_path(name) / "statements.pack.csv"
+        if write_pack:
+            pack_path.parent.mkdir(parents=True, exist_ok=True)
+            with pack_path.open("w") as fh:
+                writer = PackStatementWriter(fh)
+                dataset = Dataset(config_path, writer)
+                for spec in entities or []:
+                    entity = dataset.make(spec["schema"])
+                    entity.id = spec.get("id") or dataset.make_id(spec["schema"])
+                    for prop, values in spec["properties"].items():
+                        entity.add(prop, values)
+                    dataset.emit(entity)
+                writer.close()
+
+        return name, pack_path
+
+    return _make

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,8 +11,9 @@ from __future__ import annotations
 import os
 import tempfile
 import uuid
+from collections.abc import Callable
 from pathlib import Path
-from typing import Any, Callable
+from typing import Any
 
 _TEST_ROOT = Path(tempfile.mkdtemp(prefix="muckrake-tests-"))
 os.environ.pop("MUCKRAKE_DATABASE_URL", None)  # working DB falls back to the SQLite default
@@ -27,12 +28,11 @@ os.environ["MUCKRAKE_PUBLISHED_DATABASE_URL"] = (
 # a dataset pack.
 (_TEST_ROOT / "data").mkdir(parents=True, exist_ok=True)
 
-import muckrake  # noqa: E402  (must follow the env setup above)
-
 import pytest  # noqa: E402
 import yaml  # noqa: E402
 from followthemoney.statement.serialize import PackStatementWriter  # noqa: E402
 
+import muckrake  # noqa: E402  (must follow the env setup above)
 from muckrake.dataset import Dataset, get_dataset_path  # noqa: E402
 
 __all__ = ["muckrake"]
@@ -68,9 +68,7 @@ def make_dataset(
         config_dir = roots / name
         config_dir.mkdir(parents=True)
         config_path = config_dir / "config.yml"
-        config_path.write_text(
-            yaml.safe_dump({"name": name, "title": name, "prefix": name})
-        )
+        config_path.write_text(yaml.safe_dump({"name": name, "title": name, "prefix": name}))
 
         pack_path = get_dataset_path(name) / "statements.pack.csv"
         if write_pack:

--- a/tests/test_artifacts.py
+++ b/tests/test_artifacts.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+import json
+import uuid
+from pathlib import Path
+
+from muckrake.artifacts import LocalArtifactStore, file_sha256
+from muckrake.db import init_database
+from muckrake.runs import (
+    create_dataset_run,
+    finish_dataset_run,
+    get_latest_successful_artifact,
+    record_dataset_run_artifact,
+)
+
+
+def _unique(prefix: str) -> str:
+    return f"{prefix}_{uuid.uuid4().hex[:8]}"
+
+
+def test_put_bytes_round_trips_with_checksum(tmp_path: Path):
+    store = LocalArtifactStore(root=tmp_path)
+    stored = store.put_bytes(b"hello world", "a/b/c.txt")
+
+    assert stored.storage_backend == "local"
+    assert stored.storage_key == "a/b/c.txt"
+    assert stored.absolute_path == tmp_path / "a" / "b" / "c.txt"
+    assert stored.absolute_path.read_bytes() == b"hello world"
+    assert stored.size_bytes == len(b"hello world")
+    assert stored.sha256 == file_sha256(stored.absolute_path)
+
+
+def test_put_json_is_sorted_and_round_trips(tmp_path: Path):
+    store = LocalArtifactStore(root=tmp_path)
+    payload = {"b": 2, "a": 1}
+    stored = store.put_json(payload, "manifest.json")
+
+    text = stored.absolute_path.read_text()
+    assert json.loads(text) == payload
+    # Deterministic serialisation: keys sorted so identical payloads hash equal.
+    assert text.index('"a"') < text.index('"b"')
+    assert store.put_json(payload, "manifest2.json").sha256 == stored.sha256
+
+
+def test_put_file_copies_source(tmp_path: Path):
+    source = tmp_path / "source.csv"
+    source.write_text("id,name\n1,acme\n")
+    store = LocalArtifactStore(root=tmp_path / "store")
+
+    stored = store.put_file(source, "runs/1/statements.pack.csv")
+
+    assert stored.absolute_path.read_text() == source.read_text()
+    assert stored.sha256 == file_sha256(source)
+
+
+def test_resolve_path_and_exists(tmp_path: Path):
+    store = LocalArtifactStore(root=tmp_path)
+    key = "runs/1/x.txt"
+    assert store.resolve_path(key) == tmp_path / key
+    assert store.exists(key) is False
+    store.put_bytes(b"x", key)
+    assert store.exists(key) is True
+
+
+def test_put_bytes_same_key_overwrites(tmp_path: Path):
+    # Pins current behaviour: LocalArtifactStore does NOT enforce immutability —
+    # re-putting a storage_key overwrites in place. Artifact immutability in
+    # muckrake is a convention upheld by unique per-run storage keys
+    # (dataset-runs/<name>/<run_id>/...), not by the store. Finding for docs#38.
+    store = LocalArtifactStore(root=tmp_path)
+    first = store.put_bytes(b"one", "k")
+    second = store.put_bytes(b"two", "k")
+    assert first.absolute_path == second.absolute_path
+    assert second.absolute_path.read_bytes() == b"two"
+    assert first.sha256 != second.sha256
+
+
+def test_get_latest_successful_artifact_prefers_latest_succeeded():
+    dataset_name = _unique("arts")
+    init_database()
+
+    def _record(run_id: int, key: str) -> None:
+        record_dataset_run_artifact(
+            run_id,
+            artifact_type="statements_pack",
+            storage_backend="local",
+            storage_key=key,
+            content_type="text/csv",
+            sha256="deadbeef",
+            size_bytes=1,
+        )
+
+    first = create_dataset_run(dataset_name=dataset_name)
+    _record(first.id, f"dataset-runs/{dataset_name}/{first.id}/statements.pack.csv")
+    finish_dataset_run(first.id, "succeeded")
+
+    second = create_dataset_run(dataset_name=dataset_name)
+    second_key = f"dataset-runs/{dataset_name}/{second.id}/statements.pack.csv"
+    _record(second.id, second_key)
+    finish_dataset_run(second.id, "succeeded")
+
+    # A later failed run must not shadow the latest successful artifact.
+    failed = create_dataset_run(dataset_name=dataset_name)
+    _record(failed.id, f"dataset-runs/{dataset_name}/{failed.id}/statements.pack.csv")
+    finish_dataset_run(failed.id, "failed")
+
+    latest = get_latest_successful_artifact(dataset_name)
+    assert latest is not None
+    assert latest.storage_key == second_key

--- a/tests/test_id.py
+++ b/tests/test_id.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import warnings
+from pathlib import Path
+
+import pytest
+import yaml
+
+from muckrake.dataset import Dataset
+from muckrake.id import is_org_id, make_hashed_id, make_org_id
+
+
+def _dataset(tmp_path: Path, *, prefix: str = "tid") -> Dataset:
+    config_path = tmp_path / "config.yml"
+    config_path.write_text(
+        yaml.safe_dump({"name": "test_ids", "title": "Test IDs", "prefix": prefix})
+    )
+    return Dataset(config_path, object())
+
+
+def test_make_hashed_id_is_deterministic():
+    assert make_hashed_id("pre", "a", "b") == make_hashed_id("pre", "a", "b")
+
+
+def test_make_hashed_id_depends_on_prefix_and_parts():
+    base = make_hashed_id("pre", "a")
+    assert make_hashed_id("other", "a") != base
+    assert make_hashed_id("pre", "a", "b") != base
+
+
+def test_make_hashed_id_ignores_none_parts():
+    assert make_hashed_id("pre", "a", None, "b") == make_hashed_id("pre", "a", "b")
+
+
+def test_make_org_id_returns_gb_coh_identifier():
+    assert make_org_id("01234567", register="GB-COH") == "GB-COH-01234567"
+
+
+def test_make_org_id_normalises_whitespace_and_case():
+    assert make_org_id(" 01234567 ", register="gb-coh") == "GB-COH-01234567"
+
+
+def test_make_org_id_unknown_register_is_fallback_identifier():
+    # Unknown registers do not fail; org-id emits a scheme-prefixed fallback id
+    # (with a UserWarning). Verified behaviour, not a guess.
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        assert make_org_id("12345", register="ZZ-NOPE") == "ZZ-NOPE-12345"
+
+
+def test_make_org_id_empty_reg_nr_is_none():
+    assert make_org_id("", register="GB-COH") is None
+
+
+def test_is_org_id_recognises_org_ids_not_hashes():
+    assert is_org_id("GB-COH-01234567") is True
+    assert is_org_id(make_hashed_id("pre", "a")) is False
+
+
+def test_dataset_make_id_uses_org_id_when_reg_nr_given(tmp_path):
+    dataset = _dataset(tmp_path)
+    got = dataset.make_id("acme", reg_nr="01234567", register="GB-COH")
+    assert got == "GB-COH-01234567"
+
+
+def test_dataset_make_id_hashes_when_no_reg_nr(tmp_path):
+    got = _dataset(tmp_path, prefix="tid").make_id("acme")
+    assert got == make_hashed_id("tid", "acme")
+    # Stable across independent Dataset instances sharing the same prefix.
+    assert got == _dataset(tmp_path, prefix="tid").make_id("acme")
+
+
+def test_dataset_make_id_requires_register_with_reg_nr(tmp_path):
+    dataset = _dataset(tmp_path)
+    with pytest.raises(ValueError, match="register"):
+        dataset.make_id("acme", reg_nr="01234567")
+
+
+def test_org_id_registry_default_is_not_cached():
+    # Pins current behaviour: the installed org-id rebuilds the Registry from the
+    # bundled JSON on every Registry.default() call rather than sharing a cached
+    # instance. Known finding (docs#38): the cache fix awaits org-id v0.1.1
+    # (org-id#2 / muckrake#21); until then this is a hot-path cost at scale.
+    from org_id import Registry
+
+    assert Registry.default() is not Registry.default()

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -22,9 +22,7 @@ def _statement_count(dataset_name: str) -> int:
 
 
 def test_load_materialises_entities(make_dataset):
-    name, _ = make_dataset(
-        [{"schema": "Company", "properties": {"name": ["ACME Ltd"]}}]
-    )
+    name, _ = make_dataset([{"schema": "Company", "properties": {"name": ["ACME Ltd"]}}])
 
     run_load(name)
 
@@ -35,9 +33,7 @@ def test_load_materialises_entities(make_dataset):
 
 
 def test_reload_is_idempotent(make_dataset):
-    name, _ = make_dataset(
-        [{"schema": "Company", "properties": {"name": ["ACME Ltd"]}}]
-    )
+    name, _ = make_dataset([{"schema": "Company", "properties": {"name": ["ACME Ltd"]}}])
 
     run_load(name)
     first_count = _statement_count(name)

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from sqlalchemy import func, select
+
+from muckrake.load import run_load
+from muckrake.store import get_sql_store
+
+
+def _entities(dataset_name: str):
+    store = get_sql_store([dataset_name])
+    return list(store.view(store.dataset).entities())
+
+
+def _statement_count(dataset_name: str) -> int:
+    store = get_sql_store([dataset_name])
+    with store.engine.connect() as conn:
+        return conn.execute(
+            select(func.count())
+            .select_from(store.table)
+            .where(store.table.c.dataset == dataset_name)
+        ).scalar_one()
+
+
+def test_load_materialises_entities(make_dataset):
+    name, _ = make_dataset(
+        [{"schema": "Company", "properties": {"name": ["ACME Ltd"]}}]
+    )
+
+    run_load(name)
+
+    entities = _entities(name)
+    assert len(entities) == 1
+    assert entities[0].schema.name == "Company"
+    assert entities[0].get("name") == ["ACME Ltd"]
+
+
+def test_reload_is_idempotent(make_dataset):
+    name, _ = make_dataset(
+        [{"schema": "Company", "properties": {"name": ["ACME Ltd"]}}]
+    )
+
+    run_load(name)
+    first_count = _statement_count(name)
+    run_load(name)
+    second_count = _statement_count(name)
+
+    # run_load clears the dataset before reloading, so a re-load is a no-op:
+    # neither entities nor statements are duplicated.
+    assert first_count == second_count
+    entities = _entities(name)
+    assert len(entities) == 1
+    assert entities[0].get("name") == ["ACME Ltd"]
+
+
+def test_load_missing_pack_is_silent_noop(make_dataset):
+    # The config is discoverable but no statements.pack.csv exists. Pins current
+    # behaviour: run_load logs a warning and returns normally (no error, nothing
+    # materialised). Known finding (docs#38) — a missing pack, which can mean an
+    # upstream crawl produced no artifact, is silently skipped rather than
+    # surfaced as a failure.
+    name, pack_path = make_dataset(write_pack=False)
+    assert not pack_path.exists()
+
+    assert run_load(name) is None
+    assert _entities(name) == []
+
+
+def test_load_unknown_dataset_is_silent_noop():
+    # No config matches: run_load logs an error and returns None without raising.
+    # Pinned as current behaviour (docs#38).
+    assert run_load("dataset-that-does-not-exist") is None

--- a/tests/test_ner_apply.py
+++ b/tests/test_ner_apply.py
@@ -59,9 +59,7 @@ def _names(dataset_name: str) -> set[str]:
 def test_approved_candidate_is_applied_at_load(make_dataset):
     first, second = "Alice Zephyr", "Bob Quill"
     composite = f"{first} and {second}"
-    name, _ = make_dataset(
-        [{"schema": "Person", "properties": {"name": [composite]}}]
-    )
+    name, _ = make_dataset([{"schema": "Person", "properties": {"name": [composite]}}])
     _seed_candidate(name, first, second, approve=True)
 
     run_load(name)
@@ -77,9 +75,7 @@ def test_pending_candidate_is_not_applied_at_load(make_dataset):
     # That cross-dataset coupling is itself a finding for docs#38.
     first, second = "Carol Vane", "Dave Frost"
     composite = f"{first} and {second}"
-    name, _ = make_dataset(
-        [{"schema": "Person", "properties": {"name": [composite]}}]
-    )
+    name, _ = make_dataset([{"schema": "Person", "properties": {"name": [composite]}}])
     _seed_candidate(name, first, second, approve=False)
 
     run_load(name)

--- a/tests/test_ner_apply.py
+++ b/tests/test_ner_apply.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+from muckrake.extract.ner.pipeline import text_fingerprint
+from muckrake.extract.ner.storage import (
+    Candidate,
+    get_connection,
+    list_candidates,
+    review_candidate,
+    upsert_candidate,
+)
+from muckrake.load import run_load
+from muckrake.store import get_sql_store
+
+
+def _seed_candidate(dataset_name: str, first: str, second: str, *, approve: bool) -> str:
+    """Insert an NER candidate splitting "<first> and <second>" into two people.
+
+    Returns the composite source text. Note the candidate lookup at load time is
+    keyed only on (property_name, fingerprint) with no dataset filter, so each
+    test must use distinct names to stay isolated (see the module docstring
+    finding below).
+    """
+    source_text = f"{first} and {second}"
+    conn = get_connection()
+    try:
+        upsert_candidate(
+            conn,
+            Candidate(
+                dataset=dataset_name,
+                entity_id="seed",
+                schema="Person",
+                property_name="name",
+                source_text=source_text,
+                fingerprint=text_fingerprint(source_text),
+                extractor="test",
+                extractor_version="1",
+                extraction=[
+                    {"schema": "Person", "properties": {"name": [first]}},
+                    {"schema": "Person", "properties": {"name": [second]}},
+                ],
+            ),
+        )
+        if approve:
+            candidate_id = list_candidates(conn, dataset_name=dataset_name)[0]["id"]
+            review_candidate(conn, candidate_id, "approved")
+    finally:
+        conn.close()
+    return source_text
+
+
+def _names(dataset_name: str) -> set[str]:
+    store = get_sql_store([dataset_name])
+    names: set[str] = set()
+    for entity in store.view(store.dataset).entities():
+        names.update(entity.get("name"))
+    return names
+
+
+def test_approved_candidate_is_applied_at_load(make_dataset):
+    first, second = "Alice Zephyr", "Bob Quill"
+    composite = f"{first} and {second}"
+    name, _ = make_dataset(
+        [{"schema": "Person", "properties": {"name": [composite]}}]
+    )
+    _seed_candidate(name, first, second, approve=True)
+
+    run_load(name)
+
+    # The composite entity is replaced by the two split Person fragments.
+    assert _names(name) == {first, second}
+
+
+def test_pending_candidate_is_not_applied_at_load(make_dataset):
+    # Distinct names from the approved test on purpose: load_approved_candidates
+    # matches on (property_name, fingerprint) across ALL datasets, so reusing the
+    # same composite text would let the other test's approved candidate leak in.
+    # That cross-dataset coupling is itself a finding for docs#38.
+    first, second = "Carol Vane", "Dave Frost"
+    composite = f"{first} and {second}"
+    name, _ = make_dataset(
+        [{"schema": "Person", "properties": {"name": [composite]}}]
+    )
+    _seed_candidate(name, first, second, approve=False)
+
+    run_load(name)
+
+    # Only approved candidates are applied; the original composite name survives.
+    assert _names(name) == {composite}

--- a/tests/test_release.py
+++ b/tests/test_release.py
@@ -47,9 +47,7 @@ def _published_entities(name: str):
 
 
 def test_release_build_then_publish_copies_statements(make_dataset):
-    name, pack_path = make_dataset(
-        [{"schema": "Company", "properties": {"name": ["ACME Ltd"]}}]
-    )
+    name, pack_path = make_dataset([{"schema": "Company", "properties": {"name": ["ACME Ltd"]}}])
     _register_successful_run(name, pack_path)
 
     release_id = run_release_build([name])
@@ -77,9 +75,7 @@ def test_release_build_fails_without_successful_run(make_dataset):
 
 
 def test_release_build_is_all_or_nothing_across_datasets(make_dataset):
-    ready, ready_pack = make_dataset(
-        [{"schema": "Company", "properties": {"name": ["Ready Ltd"]}}]
-    )
+    ready, ready_pack = make_dataset([{"schema": "Company", "properties": {"name": ["Ready Ltd"]}}])
     _register_successful_run(ready, ready_pack)
     missing, _ = make_dataset(write_pack=False)
 

--- a/tests/test_release.py
+++ b/tests/test_release.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from muckrake import settings
+from muckrake.artifacts import get_artifact_store
+from muckrake.db import init_database
+from muckrake.release import (
+    get_release,
+    list_releases,
+    run_release_build,
+    run_release_publish,
+)
+from muckrake.runs import (
+    create_dataset_run,
+    finish_dataset_run,
+    record_dataset_run_artifact,
+)
+from muckrake.store import get_sql_store
+
+
+def _register_successful_run(name: str, pack_path: Path) -> int:
+    """Record a succeeded crawl run + statements artifact for a built pack."""
+    init_database()
+    run = create_dataset_run(dataset_name=name)
+    stored = get_artifact_store().put_file(
+        pack_path, f"dataset-runs/{name}/{run.id}/statements.pack.csv"
+    )
+    record_dataset_run_artifact(
+        run.id,
+        artifact_type="statements_pack",
+        storage_backend=stored.storage_backend,
+        storage_key=stored.storage_key,
+        content_type="text/csv",
+        sha256=stored.sha256,
+        size_bytes=stored.size_bytes,
+    )
+    finish_dataset_run(run.id, "succeeded")
+    return run.id
+
+
+def _published_entities(name: str):
+    store = get_sql_store([name], uri=settings.PUBLISHED_SQL_URI)
+    return list(store.view(store.dataset).entities())
+
+
+def test_release_build_then_publish_copies_statements(make_dataset):
+    name, pack_path = make_dataset(
+        [{"schema": "Company", "properties": {"name": ["ACME Ltd"]}}]
+    )
+    _register_successful_run(name, pack_path)
+
+    release_id = run_release_build([name])
+    assert get_release(release_id).status == "built"
+
+    run_release_publish(release_id)
+    assert get_release(release_id).status == "published"
+
+    published = _published_entities(name)
+    assert len(published) == 1
+    assert published[0].schema.name == "Company"
+    assert published[0].get("name") == ["ACME Ltd"]
+
+
+def test_release_build_fails_without_successful_run(make_dataset):
+    # The config is discoverable but no successful dataset run exists.
+    name, _ = make_dataset(write_pack=False)
+
+    before = len(list_releases(limit=1000))
+    with pytest.raises(ValueError, match="No successful dataset run"):
+        run_release_build([name])
+    # All-or-nothing: the failing precondition is checked before the release row
+    # is created, so no partial release is left behind. Pinned current behaviour.
+    assert len(list_releases(limit=1000)) == before
+
+
+def test_release_build_is_all_or_nothing_across_datasets(make_dataset):
+    ready, ready_pack = make_dataset(
+        [{"schema": "Company", "properties": {"name": ["Ready Ltd"]}}]
+    )
+    _register_successful_run(ready, ready_pack)
+    missing, _ = make_dataset(write_pack=False)
+
+    before = len(list_releases(limit=1000))
+    # One run-less dataset in the set aborts the whole build (current behaviour:
+    # a release covers every discovered dataset or none). Finding for docs#38.
+    with pytest.raises(ValueError, match="No successful dataset run"):
+        run_release_build([ready, missing])
+    assert len(list_releases(limit=1000)) == before


### PR DESCRIPTION
Closes #34 (docs#34). Adds focused pytest coverage for previously-untested core, running against SQLite defaults (no Postgres, no network). **52 passed** (27 new + 25 existing).

Targets against a branch of #24 (tooling baseline) so the new tests meet ruff/mypy too; rebase to main once #24 lands.

- `test_id.py` — `make_hashed_id` determinism; `make_org_id` GB-COH path, whitespace/case normalisation, unknown-register fallback; `dataset.make_id` org-id vs hashed, missing-register `ValueError`.
- `test_artifacts.py` — `LocalArtifactStore` round-trips (sha256/size), `resolve_path`/`exists`, latest-successful-artifact lookup.
- `test_load.py` — entities materialise; re-load idempotent; **pins current behaviour**: missing-pack / unknown-dataset are silent no-ops.
- `test_release.py` — build → publish into a separate SQLite DB matches; **pins** all-or-nothing build failure when a dataset lacks a successful run.
- `test_ner_apply.py` — approved candidate applied at load, pending not.
- `conftest.py` — points DB/data/artifact paths at throwaway locations before importing muckrake (settings are import-time), adds a `make_dataset` fixture.

**Findings surfaced while testing** (filed/annotated separately; the pins above document current — not necessarily desired — behaviour):
1. **NER candidate application is not dataset-scoped** — a genuine cross-dataset correctness bug (see the new issue).
2. Import-time settings capture couples `load`/`release` write paths (can't repoint without re-import).
3. `LocalArtifactStore` doesn't enforce immutability (same key overwrites).
4. `load` silent no-op on missing pack; `release-build` all-or-nothing — both feed the docs#38 hardening discussion.

https://claude.ai/code/session_01DRkQXYMJL6gBjz9nMLvFro